### PR TITLE
[cmake] Fix issue #2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,10 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 
 # find_package() should take into account <PackageName>_ROOT
-# CMake variables and environment variables
-cmake_policy(SET CMP0074 NEW)
+# CMake variables and environment variables. Requires CMake 3.12 or newer.
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif(POLICY CMP0074)
 
 # CMake options
 option(Tests "Build unit tests" ON)

--- a/cmake/find_backends.cmake
+++ b/cmake/find_backends.cmake
@@ -1,6 +1,9 @@
 message(STATUS "Detecting matrix algebra backends")
 
 # Find Eigen3
+if(NOT POLICY CMP0074)
+  set(Eigen3_DIR ${Eigen3_ROOT}/share/eigen3/cmake)
+endif(NOT POLICY CMP0074)
 find_package(Eigen3 CONFIG)
 if(Eigen3_FOUND)
   if(Eigen3_VERSION)
@@ -17,12 +20,18 @@ if(Eigen3_FOUND)
 endif(Eigen3_FOUND)
 
 # Find Blaze
+if(NOT POLICY CMP0074)
+  set(blaze_DIR ${blaze_ROOT}/share/blaze/cmake)
+endif(NOT POLICY CMP0074)
 find_package(blaze 3.0 QUIET CONFIG)
 if(blaze_FOUND)
   message(STATUS "Found Blaze version ${blaze_VERSION}")
 endif(blaze_FOUND)
 
 # Armadillo
+if(NOT POLICY CMP0074)
+  set(Armadillo_DIR ${Armadillo_ROOT}/share/Armadillo/CMake)
+endif(NOT POLICY CMP0074)
 find_package(Armadillo QUIET CONFIG)
 if(NOT Armadillo_FOUND)
   if(Armadillo_ROOT)
@@ -47,10 +56,19 @@ endif(Armadillo_FOUND)
 find_package(Boost 1.58)
 
 # Find TRIQS
+if(NOT POLICY CMP0074)
+  set(Cpp2Py_DIR ${TRIQS_ROOT}/lib/cmake/cpp2py)
+  set(TRIQS_DIR ${TRIQS_ROOT}/lib/cmake/triqs)
+endif(NOT POLICY CMP0074)
 find_package(Cpp2Py CONFIG)
 find_package(TRIQS CONFIG)
 
 # Find xtensor
+if(NOT POLICY CMP0074)
+  set(xtl_DIR ${xtensor_ROOT}/lib/cmake/xtl)
+  set(xtensor_DIR ${xtensor_ROOT}/lib/cmake/xtensor)
+  set(xtensor-blas_DIR ${xtensor-blas_ROOT}/lib/cmake/xtensor-blas)
+endif(NOT POLICY CMP0074)
 find_package(xtensor CONFIG 0.20)
 find_package(xtensor-blas CONFIG 0.16)
 if(xtensor_FOUND AND xtensor-blas_FOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Build Catch2 main object file
-add_library(catch2 OBJECT catch2/catch2-main.cpp)
+add_library(catch2 STATIC catch2/catch2-main.cpp)
 set_property(TARGET catch2 PROPERTY CXX_STANDARD 11)
 
 # Tests of raw memory storage backend


### PR DESCRIPTION
* Use CMake policy `CMP0074` only when it's available. Otherwise set some *_DIR variables as a workaround.
* Build catch2-main.cpp as a static library.

@thenoursehorse Do you think this is an adequate solution to your problem?