### PR TITLE
swap order of includes in nda storage

### DIFF
--- a/include/ezarpack/storages/nda.hpp
+++ b/include/ezarpack/storages/nda.hpp
@@ -15,8 +15,8 @@
 #include <cmath>
 #include <complex>
 
-#include <nda/blas/dot.hpp>
 #include <nda/nda.hpp>
+#include <nda/blas/dot.hpp>
 
 #include "base.hpp"
 


### PR DESCRIPTION
This is very minor.

When compiling with gcc12, the dot will fail because of the EXPECTS macro due to the linking getting messed up. This is fixed if nda.hpp is included before dot.hpp.