### PR TITLE
Make MPI support opt-out.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,19 +23,22 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 
 # CMake options
-option(Tests "Build unit tests" ON)
-option(Examples "Build examples" ON)
 option(Documentation "Build documentation" OFF)
+option(EnableMPI "Build with MPI support (PARPACK)" ON)
+option(Examples "Build examples" ON)
+option(Tests "Build unit tests" ON)
 
 # Are we building any executables?
 if(Tests OR Examples)
 
   # Detect an MPI implementation for MPI-tests and/or examples
-  find_package(MPI 3.0)
-  if(MPI_FOUND)
-    message(STATUS "MPI_CXX_INCLUDE_PATH: ${MPI_CXX_INCLUDE_PATH}")
-    message(STATUS "MPI_CXX_LIBRARIES: ${MPI_CXX_LIBRARIES}")
-  endif(MPI_FOUND)
+  if (EnableMPI)
+    find_package(MPI 3.0)
+    if(MPI_FOUND)
+      message(STATUS "MPI_CXX_INCLUDE_PATH: ${MPI_CXX_INCLUDE_PATH}")
+      message(STATUS "MPI_CXX_LIBRARIES: ${MPI_CXX_LIBRARIES}")
+    endif(MPI_FOUND)
+  endif(EnableMPI)
 
   # Detect ARPACK-NG
   include(cmake/FindARPACKNG.cmake)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ -DCMAKE_INSTALL_PREFIX=<ezARPACK_installation_prefix>   \
   -Dnda_ROOT=<nda_installation_prefix>                    \
   -Dxtensor_ROOT=<xtensor_installation_prefix>            \
   -Dxtensor-blas_ROOT=<xtensor-blas_installation_prefix>  \
+  -DEnableMPI=ON                                          \
   -DExamples=ON                                           \
   -DTests=ON
 $ make
@@ -89,6 +90,9 @@ Compilation of the tests can be disabled with CMake flag `-DTests=OFF`
 *(not recommended)*.
 
 Examples are compiled by default, disable them with `-DExamples=OFF`.
+
+Detection of an MPI implementation and compilation of the MPI-enabled unit tests
+and examples can be skipped by setting `-DEnableMPI=OFF`.
 
 CMake options specific to individual storage backends (`Eigen3_ROOT`,
 `blaze_ROOT`, `Armadillo_ROOT`, `BOOST_ROOT`, `TRIQS_ROOT`, `nda_ROOT`
@@ -242,7 +246,7 @@ to MPI libraries.
 add_executable(myprog_mpi myprog_mpi.cpp)
 target_link_libraries(myprog_mpi ezarpack Eigen3::Eigen)
 
-# Detect and MPI-3.0 implementation.
+# Detect an MPI-3.0 implementation.
 find_package(MPI 3.0 REQUIRED)
 
 # Link the executable to the Parallel ARPACK library and to the MPI.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -40,6 +40,7 @@ The following sequence of shell commands will build unit tests and examples.
       -Dnda_ROOT=<nda_installation_prefix>                    \
       -Dxtensor_ROOT=<xtensor_installation_prefix>            \
       -Dxtensor-blas_ROOT=<xtensor-blas_installation_prefix>  \
+      -DEnableMPI=ON                                          \
       -DExamples=ON                                           \
       -DTests=ON
     $ make
@@ -76,7 +77,9 @@ a working implementation of MPI-3.0 or newer. If CMake is unable to detect one
 automatically, refer to
 `this list of environment variables
 <https://cmake.org/cmake/help/latest/module/FindMPI.html#variables-for-locating-mpi>`_
-that affect CMake's search procedure.
+that affect CMake's search procedure. It is possible to skip MPI detection and
+compilation of PARPACK unit tests and examples altogether by setting
+``-DEnableMPI=OFF``.
 
 Documentation of ezARPACK can optionally be built and installed using the
 ``Documentation`` CMake flag (requires `Doxygen <https://www.doxygen.nl/>`_,
@@ -101,6 +104,10 @@ meaning.
 +-----------------------------+------------------------------------------------+
 | ``Examples=[ON|OFF]``       | Enable/disable compilation of example          |
 |                             | programs.                                      |
++-----------------------------+------------------------------------------------+
+| ``EnableMPI=[ON|OFF]``      | Enable/disable detection of an MPI             |
+|                             | implementation for PARPACK unit tests and      |
+|                             | examples.                                      |
 +-----------------------------+------------------------------------------------+
 | ``ARPACK_NG_ROOT``          | Path to ARPACK-NG installation.                |
 +-----------------------------+------------------------------------------------+


### PR DESCRIPTION
**Context:** 
When ARPACK-NG is compiled without MPI support (i.e. PARPACK is nowhere to be found) but some MPI implementation is found by CMake, the build fails because the examples and tests are expecting PARPACK.

**Description of the Change:**
Add the CMake build option `EnableMPI` enabling a serial build of the examples and tests even when MPI is found on the system. I've made it opt-out to preserve the current behavior.

**Benefits:**
More flexibility in build & test options.

**Possible Drawbacks:**

**Related Issues:**